### PR TITLE
refactor: moving shared errors to baseRouter

### DIFF
--- a/src/interfaces/ISwapRouterBase.sol
+++ b/src/interfaces/ISwapRouterBase.sol
@@ -6,6 +6,16 @@ import {IHooks} from "pancake-v4-core/src/interfaces/IHooks.sol";
 import {IPoolManager} from "pancake-v4-core/src/interfaces/IPoolManager.sol";
 
 interface ISwapRouterBase {
+    error DeadlineExceeded(uint256, uint256);
+
+    error InvalidSwapType();
+
+    /// @notice throw when output token traders receive less than the expected amount
+    error TooLittleReceived();
+
+    /// @notice throw when input token pool requests more than traders allowed amount
+    error TooMuchRequested();
+
     struct PathKey {
         Currency intermediateCurrency;
         uint24 fee;

--- a/src/pool-bin/BinSwapRouterBase.sol
+++ b/src/pool-bin/BinSwapRouterBase.sol
@@ -98,13 +98,13 @@ abstract contract BinSwapRouterBase is SwapRouterBase, IBinSwapRouterBase {
     ) internal returns (uint256 amountIn) {
         (uint128 amtIn,,) = binPoolManager.getSwapIn(params.poolKey, params.swapForY, params.amountOut);
 
-        if (amtIn > params.amountInMaximum) revert MaxAmountInExceeded();
+        if (amtIn > params.amountInMaximum) revert TooMuchRequested();
 
         uint128 amountOutReal = _swapExactPrivate(
             params.poolKey, params.swapForY, msgSender, params.recipient, amtIn, settle, take, params.hookData
         );
 
-        if (amountOutReal < params.amountOut) revert InsufficientAmountOut();
+        if (amountOutReal < params.amountOut) revert TooLittleReceived();
 
         amountIn = uint256(amtIn);
     }
@@ -145,7 +145,7 @@ abstract contract BinSwapRouterBase is SwapRouterBase, IBinSwapRouterBase {
 
             /// @dev only check amountOut for the last path since thats what the user cares
             if (i == state.pathLength) {
-                if (state.amountOut < params.amountOut) revert InsufficientAmountOut();
+                if (state.amountOut < params.amountOut) revert TooLittleReceived();
             }
 
             params.amountOut = state.amountIn;
@@ -156,7 +156,7 @@ abstract contract BinSwapRouterBase is SwapRouterBase, IBinSwapRouterBase {
             }
         }
 
-        if (state.amountIn > params.amountInMaximum) revert MaxAmountInExceeded();
+        if (state.amountIn > params.amountInMaximum) revert TooMuchRequested();
         amountIn = uint256(state.amountIn);
     }
 

--- a/src/pool-bin/interfaces/IBinSwapRouter.sol
+++ b/src/pool-bin/interfaces/IBinSwapRouter.sol
@@ -5,9 +5,6 @@ pragma solidity ^0.8.19;
 import {IBinSwapRouterBase} from "./IBinSwapRouterBase.sol";
 
 interface IBinSwapRouter is IBinSwapRouterBase {
-    error DeadlineExceeded(uint256, uint256);
-    error InvalidSwapType();
-
     enum SwapType {
         ExactInput,
         ExactInputSingle,

--- a/src/pool-bin/interfaces/IBinSwapRouterBase.sol
+++ b/src/pool-bin/interfaces/IBinSwapRouterBase.sol
@@ -7,10 +7,6 @@ import {Currency} from "pancake-v4-core/src/types/Currency.sol";
 import {ISwapRouterBase} from "../../interfaces/ISwapRouterBase.sol";
 
 interface IBinSwapRouterBase is ISwapRouterBase {
-    error TooLittleReceived();
-    error MaxAmountInExceeded();
-    error InsufficientAmountOut();
-
     struct V4BinExactInputSingleParams {
         PoolKey poolKey;
         bool swapForY;

--- a/src/pool-cl/interfaces/ICLSwapRouter.sol
+++ b/src/pool-cl/interfaces/ICLSwapRouter.sol
@@ -5,8 +5,6 @@ pragma solidity ^0.8.19;
 import {ICLSwapRouterBase} from "./ICLSwapRouterBase.sol";
 
 interface ICLSwapRouter is ICLSwapRouterBase {
-    error DeadlineExceeded(uint256 deladline, uint256 now);
-
     enum SwapType {
         ExactInput,
         ExactInputSingle,

--- a/src/pool-cl/interfaces/ICLSwapRouterBase.sol
+++ b/src/pool-cl/interfaces/ICLSwapRouterBase.sol
@@ -8,10 +8,6 @@ import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
 import {ISwapRouterBase} from "../../interfaces/ISwapRouterBase.sol";
 
 interface ICLSwapRouterBase is ISwapRouterBase {
-    error InvalidSwapType();
-    error TooLittleReceived();
-    error TooMuchRequested();
-
     struct V4CLExactInputSingleParams {
         PoolKey poolKey;
         bool zeroForOne;

--- a/test/pool-bin/BinSwapRouter.t.sol
+++ b/test/pool-bin/BinSwapRouter.t.sol
@@ -312,7 +312,7 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
 
         token0.mint(alice, 1 ether);
 
-        vm.expectRevert(IBinSwapRouterBase.TooLittleReceived.selector);
+        vm.expectRevert(ISwapRouterBase.TooLittleReceived.selector);
         router.exactInputSingle(
             IBinSwapRouterBase.V4BinExactInputSingleParams({
                 poolKey: key,
@@ -480,7 +480,7 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
             parameters: key.parameters
         });
 
-        vm.expectRevert(IBinSwapRouterBase.TooLittleReceived.selector);
+        vm.expectRevert(ISwapRouterBase.TooLittleReceived.selector);
         router.exactInput(
             IBinSwapRouterBase.V4BinExactInputParams({
                 currencyIn: Currency.wrap(address(token0)),
@@ -582,7 +582,7 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
 
         token0.mint(alice, 1 ether);
 
-        vm.expectRevert(abi.encodeWithSelector(IBinSwapRouterBase.MaxAmountInExceeded.selector));
+        vm.expectRevert(abi.encodeWithSelector(ISwapRouterBase.TooMuchRequested.selector));
         router.exactOutputSingle(
             IBinSwapRouterBase.V4ExactOutputSingleParams({
                 poolKey: key,
@@ -596,7 +596,7 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
         );
     }
 
-    function testExactOutputSingle_InsufficientAmountOut() public {
+    function testExactOutputSingle_TooLittleReceived() public {
         //todo: in order to simulate this error, require
         //     // 1. hooks at beforeSwap do something funny on the pool resulting in actual amountOut lesser
     }
@@ -707,7 +707,7 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
         );
     }
 
-    function testExactOutput_MaxAmountInExceeded() public {
+    function testExactOutput_TooMuchRequested() public {
         vm.startPrank(alice);
         token0.mint(alice, 2 ether);
 
@@ -721,7 +721,7 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
             parameters: key.parameters
         });
 
-        vm.expectRevert(abi.encodeWithSelector(IBinSwapRouterBase.MaxAmountInExceeded.selector));
+        vm.expectRevert(abi.encodeWithSelector(ISwapRouterBase.TooMuchRequested.selector));
         router.exactOutput(
             IBinSwapRouterBase.V4ExactOutputParams({
                 currencyOut: Currency.wrap(address(token1)),
@@ -806,9 +806,4 @@ contract BinSwapRouterTest is Test, GasSnapshot, LiquidityParamsHelper {
             assertEq(currency0Balance, excessTokenAmount, "Unexpected currency0 balance in vault");
         }
     }
-
-    // function testExactOutput_InsufficientAmountOut() public {
-    //     //todo: in order to simulate this error, require
-    //     // 1. hooks at beforeSwap do something funny on the pool resulting in actual amountOut lesser
-    // }
 }

--- a/test/pool-cl/CLSwapRouter.t.sol
+++ b/test/pool-cl/CLSwapRouter.t.sol
@@ -263,7 +263,7 @@ contract CLSwapRouterTest is TokenFixture, Test, GasSnapshot {
     }
 
     function testExactInputSingle_amountOutLessThanExpected() external {
-        vm.expectRevert(ICLSwapRouterBase.TooLittleReceived.selector);
+        vm.expectRevert(ISwapRouterBase.TooLittleReceived.selector);
         router.exactInputSingle(
             ICLSwapRouterBase.V4CLExactInputSingleParams({
                 poolKey: poolKey0,
@@ -366,7 +366,7 @@ contract CLSwapRouterTest is TokenFixture, Test, GasSnapshot {
     }
 
     function testExactInput_amountOutLessThanExpected() external {
-        vm.expectRevert(ICLSwapRouterBase.TooLittleReceived.selector);
+        vm.expectRevert(ISwapRouterBase.TooLittleReceived.selector);
         ISwapRouterBase.PathKey[] memory path = new ISwapRouterBase.PathKey[](2);
         path[0] = ISwapRouterBase.PathKey({
             intermediateCurrency: currency1,
@@ -514,7 +514,7 @@ contract CLSwapRouterTest is TokenFixture, Test, GasSnapshot {
     }
 
     function testExactOutputSingle_amountOutLessThanExpected() external {
-        vm.expectRevert(ICLSwapRouterBase.TooMuchRequested.selector);
+        vm.expectRevert(ISwapRouterBase.TooMuchRequested.selector);
 
         router.exactOutputSingle(
             ICLSwapRouterBase.V4CLExactOutputSingleParams({
@@ -624,7 +624,7 @@ contract CLSwapRouterTest is TokenFixture, Test, GasSnapshot {
     }
 
     function testExactOutput_amountInMoreThanExpected() external {
-        vm.expectRevert(ICLSwapRouterBase.TooMuchRequested.selector);
+        vm.expectRevert(ISwapRouterBase.TooMuchRequested.selector);
 
         ISwapRouterBase.PathKey[] memory path = new ISwapRouterBase.PathKey[](2);
         path[0] = ISwapRouterBase.PathKey({


### PR DESCRIPTION
## Context

This PR moves and uniform errors in different pool types into ISwapRouterBase.sol, so that all pool type can reuse the same error.  It helps to avoid conflicts when implementing universal router. 