### PR TITLE
fix: Remove compile warning

### DIFF
--- a/src/pool-cl/NonfungibleTokenPositionDescriptorOffChain.sol
+++ b/src/pool-cl/NonfungibleTokenPositionDescriptorOffChain.sol
@@ -22,6 +22,7 @@ contract NonfungibleTokenPositionDescriptorOffChain is INonfungibleTokenPosition
         override
         returns (string memory)
     {
+        delete positionManager;
         return bytes(_baseTokenURI).length > 0 ? string.concat(_baseTokenURI, tokenId.toString()) : "";
     }
 }


### PR DESCRIPTION
Now tokenURI function does not use the parameter positionManager. 
So we can remove compile warning by deleting positionManager

![Screenshot 2024-07-26 at 11 19 17](https://github.com/user-attachments/assets/8f67686f-d51e-4d2e-904e-a1da10d79d23)
